### PR TITLE
sepolicy: address more denials

### DIFF
--- a/sensors/wake/Sensor.h
+++ b/sensors/wake/Sensor.h
@@ -124,6 +124,7 @@ static const char* udfpsPaths[] = {
   "/sys/kernel/oplus_display/fp_state",
   "/sys/devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/fp_pressed",
   "/sys/devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi1/spi1.0/synaptics_tcm_hbp.0/fp_pressed",
+  "/sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/fp_pressed",
   "/proc/touchpanel/i2c/udfps_pressed",
   NULL
 };
@@ -141,6 +142,7 @@ class UdfpsSensor : public SysfsPollingOneShotSensor {
 static const char* doubleTapPaths[] = {
   "/sys/devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/double_tap_pressed",
   "/sys/devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi1/spi1.0/synaptics_tcm_hbp.0/double_tap_pressed",
+  "/sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/double_tap_pressed",
   "/proc/touchpanel/i2c/double_tap_pressed",
   NULL
 };

--- a/sepolicy/qti/private/system_app.te
+++ b/sepolicy/qti/private/system_app.te
@@ -1,0 +1,4 @@
+# Suspend
+dontaudit system_app system_suspend_control_service:service_manager { find };
+dontaudit system_app system_suspend_control_internal_service:service_manager { find };
+dontaudit system_app tracingproxy_service:service_manager { find };

--- a/sepolicy/qti/private/system_suspend.te
+++ b/sepolicy/qti/private/system_suspend.te
@@ -1,0 +1,4 @@
+# Allow system_suspend to read wakeup source stats from sysfs
+allow system_suspend sysfs_wakeup:dir r_dir_perms;
+allow system_suspend sysfs_wakeup:file r_file_perms;
+allow system_suspend sysfs_wakeup:lnk_file r_file_perms;

--- a/sepolicy/qti/vendor/genfs_contexts
+++ b/sepolicy/qti/vendor/genfs_contexts
@@ -141,6 +141,7 @@ genfscon sysfs /devices/platform/soc/aab0000.qcom,venus/subsys9/wakeup u:object_
 genfscon sysfs /devices/platform/soc/abb0000.qcom,cvpss/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a8c000.i2c/i2c-9/9-000e/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a8c000.i2c/i2c-10/10-000e/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a84000.i2c/i2c-5/5-006f/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a80000.i2c/i2c-10/10-0028/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a8c000.i2c/i2c-11/11-000e/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a80000.i2c/i2c-11/11-0028/wakeup u:object_r:sysfs_wakeup:s0
@@ -171,6 +172,7 @@ genfscon sysfs /devices/platform/soc/soc:discrete_charger/power_supply/ac/wakeup
 genfscon sysfs /devices/platform/soc/soc:discrete_charger/power_supply/battery/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:discrete_charger/power_supply/usb/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:discrete_charger/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/soc:gpio-hall-sensor/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:oneplus_wlchg/power_supply/wireless/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:oneplus_wlchg/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/soc:oplus,chg_gki/power_supply/battery/wakeup u:object_r:sysfs_wakeup:s0

--- a/sepolicy/qti/vendor/genfs_contexts
+++ b/sepolicy/qti/vendor/genfs_contexts
@@ -78,6 +78,9 @@ genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi1/spi1.0/synaptics_tcm_hbp.0/single_tap_pressed    u:object_r:vendor_sysfs_sensor_tap:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi1/spi1.0/synaptics_tcm_hbp.0/double_tap_pressed    u:object_r:vendor_sysfs_sensor_tap:s0
 genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_1_geni_se/a90000.spi/spi_master/spi1/spi1.0/synaptics_tcm_hbp.0/fp_pressed            u:object_r:vendor_sysfs_sensor_tap:s0
+genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/double_tap_pressed    u:object_r:vendor_sysfs_sensor_tap:s0
+genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/single_tap_pressed    u:object_r:vendor_sysfs_sensor_tap:s0
+genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/fp_pressed    u:object_r:vendor_sysfs_sensor_tap:s0
 
 # TOF
 genfscon sysfs /kernel/tof_control    u:object_r:vendor_sysfs_tof:s0

--- a/sepolicy/qti/vendor/genfs_contexts
+++ b/sepolicy/qti/vendor/genfs_contexts
@@ -119,6 +119,11 @@ genfscon sysfs /devices/platform/soc/8c0000.qcom,qupv3_0_geni_se/880000.spi/spi_
 genfscon sysfs /devices/platform/soc/8c0000.qcom,qupv3_2_geni_se/884000.i2c/i2c-7/7-0010/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/8c0000.qcom,qupv3_2_geni_se/884000.i2c/i2c-8/8-0010/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/8c0000.qcom,qupv3_2_geni_se/884000.i2c/i2c-9/9-0010/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/8c0000.qcom,qupv3_1_geni_se/884000.i2c/i2c-9/9-0028/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a90000.spi/spi_master/spi0/spi0.0/synaptics_tcm_hbp.0/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/c42d000.qcom,spmi/spmi-0/0-00/c42d000.qcom,spmi:qcom,pmk8550@0:rtc@6100/rtc/rtc0/alarmtimer.2.auto/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/soc:oplus,plc_charge/oplus_mms/plc/wakeup u:object_r:sysfs_wakeup:s0
+genfscon sysfs /devices/platform/soc/soc:oplus,retention_charge/oplus_mms/retention/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/9c0000.qcom,qupv3_i2c_geni_se/98c000.i2c/i2c-5/5-003b/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/980000.i2c/i2c-0/0-003b/wakeup u:object_r:sysfs_wakeup:s0
 genfscon sysfs /devices/platform/soc/980000.i2c/i2c-7/7-003b/wakeup u:object_r:sysfs_wakeup:s0

--- a/sepolicy/qti/vendor/system_app.te
+++ b/sepolicy/qti/vendor/system_app.te
@@ -1,2 +1,9 @@
 # Allow KProfiles to be adjusted by a system app
 allow system_app sysfs_kprofiles:file rw_file_perms;
+allow system_app hal_camera_default:binder call;
+allow system_app hal_fingerprint_default:binder call;
+allow system_app hal_bootctl_default:binder call;
+
+# Zram
+allow system_app sysfs_zram:dir r_dir_perms;
+allow system_app sysfs_zram:file r_file_perms;


### PR DESCRIPTION
- **sensors: add sm7675 touchpanel interfaces - sm8635 is same**
- **sepolicy: qti: Label lexus wakeup nodes**
- **sepolicy: Label more wakeup nodes**
- **sepolicy: address bindercall and zram scam**
- **sepolicy: Allow system_suspend to read sysfs_wakeup**
- **sepolicy: Fix denials during suspend**
